### PR TITLE
doc(vhpidirect/examples): break section statement out of IMPORTANT

### DIFF
--- a/doc/vhpidirect/examples/index.rst
+++ b/doc/vhpidirect/examples/index.rst
@@ -4,9 +4,11 @@ Examples
 ########
 
 .. IMPORTANT::
-  This sections contains advanced examples using specific features of the language, the tool,
-  or interaction with third-party projects. It is suggested for users who are new to either
+   It is suggested for users who are new to either
   `GHDL` or `VHDL` to read :ref:`USING:QuickStart` first.
+
+This sections contains advanced examples using specific features of the language, the tool,
+or interaction with third-party projects.
 
 .. toctree::
 


### PR DESCRIPTION
From ghdl/ghdl/pull/1223

The existing change to vhpidirect/examples/index.rst is pretty much what I wanted.
Only I would break one sentence out of the IMPORTANT block